### PR TITLE
Refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "autocfg"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
 name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,15 +102,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "classic-bindings"
-version = "0.1.1"
+name = "chrono"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff5f775aae6e8b7b9237559522ec4cbc4870ab42706d55488ee1353d6b97304"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "classic-bindings"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5997c062dff68c15b541917f7e9a754d4b2710442449ca23031c2a1f4cba460a"
+dependencies = [
+ "classic-rust",
  "cosmwasm-schema",
  "cosmwasm-std",
+ "prost 0.11.9",
  "schemars",
  "serde",
+]
+
+[[package]]
+name = "classic-rust"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d86286dfe6e1a77f005cbf0d32eaa93e173adba1ec67cd3e6d007ac56b94d17"
+dependencies = [
+ "chrono",
+ "cosmwasm-std",
+ "osmosis-std-derive",
+ "prost 0.11.9",
+ "prost-types",
+ "schemars",
+ "serde",
+ "serde-cw-value",
 ]
 
 [[package]]
@@ -261,7 +294,7 @@ dependencies = [
  "derivative",
  "itertools",
  "k256 0.11.6",
- "prost",
+ "prost 0.9.0",
  "schemars",
  "serde",
  "thiserror",
@@ -272,6 +305,17 @@ name = "cw-storage-plus"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6cf70ef7686e2da9ad7b067c5942cd3e88dd9453f7af42f54557f8af300fb0"
+dependencies = [
+ "cosmwasm-std",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "cw-storage-plus"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b6f91c0b94481a3e9ef1ceb183c37d00764f8751e39b45fc09f4d9b970d469"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -291,13 +335,13 @@ dependencies = [
 
 [[package]]
 name = "cw-utils"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae0b69fa7679de78825b4edeeec045066aa2b2c4b6e063d80042e565bb4da5c"
+checksum = "d6a84c6c1c0acc3616398eba50783934bd6c964bad6974241eaee3460c8f5b26"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw2 0.15.1",
+ "cw2 0.16.0",
  "schemars",
  "semver",
  "serde",
@@ -321,13 +365,13 @@ dependencies = [
 
 [[package]]
 name = "cw2"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5abb8ecea72e09afff830252963cb60faf945ce6cef2c20a43814516082653da"
+checksum = "91398113b806f4d2a8d5f8d05684704a20ffd5968bf87e3473e1973710b884ad"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.15.1",
+ "cw-storage-plus 0.16.0",
  "schemars",
  "serde",
 ]
@@ -349,28 +393,28 @@ dependencies = [
 
 [[package]]
 name = "cw20"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6025276fb6e603e974c21f3e4606982cdc646080e8fba3198816605505e1d9a"
+checksum = "a45a8794a5dd33b66af34caee52a7beceb690856adcc1682b6e3db88b2cdee62"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-utils 0.15.1",
+ "cw-utils 0.16.0",
  "schemars",
  "serde",
 ]
 
 [[package]]
 name = "cw20-base"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0909c56d0c14601fbdc69382189799482799dcad87587926aec1f3aa321abc41"
+checksum = "61d826fa1084d026d0abdb54faa5956972efa3a9053473bfcefb5388960aab69"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.15.1",
- "cw-utils 0.15.1",
- "cw2 0.15.1",
+ "cw-storage-plus 0.16.0",
+ "cw-utils 0.16.0",
+ "cw2 0.16.0",
  "cw20",
  "schemars",
  "semver",
@@ -664,6 +708,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,6 +727,19 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "osmosis-std-derive"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5ebdfd1bc8ed04db596e110c6baa9b174b04f6ed1ec22c666ddc5cb3fa91bd7"
+dependencies = [
+ "itertools",
+ "proc-macro2",
+ "prost-types",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "pkcs8"
@@ -711,7 +777,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.9.0",
+]
+
+[[package]]
+name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive 0.11.9",
 ]
 
 [[package]]
@@ -725,6 +801,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+dependencies = [
+ "prost 0.11.9",
 ]
 
 [[package]]
@@ -843,6 +941,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-cw-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75d32da6b8ed758b7d850b6c3c08f1d7df51a4df3cb201296e63e34a78e99d4"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -995,7 +1102,7 @@ dependencies = [
  "cosmwasm-storage",
  "cw-multi-test",
  "cw-storage-plus 0.15.1",
- "cw2 0.15.1",
+ "cw2 0.16.0",
  "cw20",
  "cw20-base",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,12 @@
 members = ["contracts/*", "packages/*"]
 
 [profile.release]
+opt-level = 3
+debug = false
 rpath = false
 lto = true
+debug-assertions = false
+codegen-units = 1
+panic = 'abort'
+incremental = false
 overflow-checks = true

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
-# TestGenericDeps
- cw-multitest instantiate contract with entry point having specific DepsMut<TerraQuery> and Deps<TerraQuery> param
+# Test generic dependencies
+
+**cw-multi-test** instantiate contract with entry points
+having specific `DepsMut<TerraQuery>` and `Deps<TerraQuery>` arguments, where
+`TerraQuery` is from [`classic-bindings`](https://crates.io/crates/classic-bindings).
+
+### Useful round-trip commands
+
+Clean everything
+
+```shell
+cargo clean
+```
+
+Build the project
+
+```shell
+cargo build --workspace
+```
+
+Check the code with `clippy`
+
+```shell
+cargo clippy --all-targets --workspace
+```
+
+Run tests
+
+```shell
+cargo test --workspace
+```

--- a/contracts/test01/Cargo.toml
+++ b/contracts/test01/Cargo.toml
@@ -10,16 +10,16 @@ crate-type = ["cdylib", "rlib"]
 library = []
 
 [dependencies]
-cosmwasm-std = "1.5.0"
-cosmwasm-storage = "1.5.0"
-cosmwasm-schema = "1.5.0"
-serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-cw2 = { version = "0.15.1" }
-cw20 = { version = "0.15.1" }
+cosmwasm-std = "1.5.5"
+cosmwasm-storage = "1.5.2"
+cosmwasm-schema = "1.5.5"
+serde = { version = "1.0.204", default-features = false, features = ["derive"] }
+cw2 = { version = "0.16.0" }
+cw20 = { version = "0.16.0" }
 cw-storage-plus = { version = "0.15.1" }
-thiserror = "1.0.35"
-classic-bindings = { version = "0.1.1" }
+thiserror = "1.0.61"
+classic-bindings = { version = "0.2.1" }
 
 [dev-dependencies]
-cw-multi-test =  { version = "0.16.0" }
-cw20-base = { version = "0.15.1", features = ["library"] }
+cw-multi-test = { version = "0.16.5" }
+cw20-base = { version = "0.16.0", features = ["library"] }

--- a/contracts/test01/Cargo.toml
+++ b/contracts/test01/Cargo.toml
@@ -6,17 +6,6 @@ edition = "2018"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[profile.release]
-opt-level = 3
-debug = false
-rpath = false
-lto = true
-debug-assertions = false
-codegen-units = 1
-panic = 'abort'
-incremental = false
-overflow-checks = true
-
 [features]
 library = []
 

--- a/contracts/test01/README.md
+++ b/contracts/test01/README.md
@@ -1,0 +1,10 @@
+# Test `Deps<TerraQuery>` with [cw-multi-test](https://crates.io/crates/cw-multi-test)
+
+Trying to use [cw-multi-test](https://crates.io/crates/cw-multi-test) instantiate contract
+when the contract entry points are in the format:
+
+```text
+instantiate(deps: DepsMut<TerraQuery>, env: Env, _info: MessageInfo, msg: InstantiateMsg)
+```
+
+where `TerraQuery` is from [`classic-bindings`](https://crates.io/crates/classic-bindings).

--- a/contracts/test01/Readme.md
+++ b/contracts/test01/Readme.md
@@ -1,6 +1,0 @@
-# Test `Deps<TerraQuery>` with `cw-multitest`
-
-trying to use cw-multitest instantiate contract when the contract entrypoints are in that format:
-`instantiate( deps: DepsMut<TerraQuery>, env: Env, _info: MessageInfo, msg: InstantiateMsg,)`
-
-`TerraQuery` is from `classic-bindings`

--- a/contracts/test01/src/contract.rs
+++ b/contracts/test01/src/contract.rs
@@ -1,12 +1,12 @@
-use classic_bindings::TerraQuery;
-use cosmwasm_std::{
-    entry_point, to_json_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Response, StdResult
-};
-
 use crate::error::ContractResponse;
 use crate::msg::{InstantiateMsg, QueryMsg};
 use crate::query::query_config;
 use crate::state::instantiate_contract;
+use classic_bindings::TerraQuery;
+use cosmwasm_std::{
+    entry_point, to_json_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Response,
+    StdResult,
+};
 
 #[entry_point]
 pub fn instantiate(
@@ -23,7 +23,7 @@ pub fn execute(
     _deps: DepsMut<TerraQuery>,
     _env: Env,
     _info: MessageInfo,
-    _: Empty
+    _: Empty,
 ) -> ContractResponse {
     Ok(Response::new())
 }

--- a/contracts/test01/src/lib.rs
+++ b/contracts/test01/src/lib.rs
@@ -1,8 +1,8 @@
 pub mod contract;
+pub mod error;
 pub mod msg;
 pub mod query;
 pub mod state;
-pub mod error;
 
-#[cfg(any(test, feature = "tests"))]
+#[cfg(test)]
 mod tests;

--- a/contracts/test01/src/tests/mod.rs
+++ b/contracts/test01/src/tests/mod.rs
@@ -1,2 +1,3 @@
+mod test_instantiate;
+mod test_minting;
 mod utils;
-mod tests;

--- a/contracts/test01/src/tests/test_instantiate.rs
+++ b/contracts/test01/src/tests/test_instantiate.rs
@@ -1,0 +1,26 @@
+use super::utils::*;
+
+#[test]
+fn instantiate_check_config() {
+    let mut app = my_app();
+    let (test01_contract_addr, token_contract_addr) = init_contracts(&mut app);
+
+    // TODO Remove the following lines when contract addresses are used somewhere else.
+    assert_eq!("contract0", token_contract_addr.as_str());
+    assert_eq!("contract1", test01_contract_addr.as_str());
+}
+
+#[test]
+fn instantiating_token_contract_should_work() {
+    let mut app = my_app();
+    let token_contract_addr = init_token_contract(&mut app);
+    assert_eq!("contract0", token_contract_addr.as_str());
+}
+
+#[test]
+fn instantiating_test01_contract_should_work() {
+    let mut app = my_app();
+    let token_contract_addr = init_token_contract(&mut app);
+    let test01_contract_addr = init_test01_contract(&mut app, &token_contract_addr);
+    assert_eq!("contract1", test01_contract_addr.as_str());
+}

--- a/contracts/test01/src/tests/test_minting.rs
+++ b/contracts/test01/src/tests/test_minting.rs
@@ -1,7 +1,12 @@
-use crate::tests::utils::{addr, governance_addr, init_token_contract, mint_some_tokens, my_app};
+use crate::tests::utils::{
+    addr, governance_addr, init_token_contract, mint_tokens, my_app, query_tokens,
+};
 
 #[test]
 fn minting_come_tokens_should_work() {
+    // amount of tokens to be minted
+    const AMOUNT: u128 = 100;
+
     // create my chain
     let mut app = my_app();
 
@@ -13,11 +18,17 @@ fn minting_come_tokens_should_work() {
     let token_contract_addr = init_token_contract(&mut app);
 
     // mint some tokens for the recipient
-    mint_some_tokens(
+    mint_tokens(
         &mut app,
         &governance_addr,
         &token_contract_addr,
-        100,
+        AMOUNT,
         &recipient_addr,
+    );
+
+    // make sure that the recipient has the expected amount of tokens
+    assert_eq!(
+        AMOUNT,
+        query_tokens(&app, &token_contract_addr, &recipient_addr)
     );
 }

--- a/contracts/test01/src/tests/test_minting.rs
+++ b/contracts/test01/src/tests/test_minting.rs
@@ -1,0 +1,23 @@
+use crate::tests::utils::{addr, governance_addr, init_token_contract, mint_some_tokens, my_app};
+
+#[test]
+fn minting_come_tokens_should_work() {
+    // create my chain
+    let mut app = my_app();
+
+    // prepare governance and recipient addresses
+    let governance_addr = governance_addr();
+    let recipient_addr = addr("recipient");
+
+    // instantiate token contract and get its address
+    let token_contract_addr = init_token_contract(&mut app);
+
+    // mint some tokens for the recipient
+    mint_some_tokens(
+        &mut app,
+        &governance_addr,
+        &token_contract_addr,
+        100,
+        &recipient_addr,
+    );
+}

--- a/contracts/test01/src/tests/tests.rs
+++ b/contracts/test01/src/tests/tests.rs
@@ -1,9 +1,0 @@
-use super::utils::{init_contracts, mock_app};
-
-#[test]
-fn instantiate_check_config() {
-    let app = &mut mock_app();
-    let (test01_contract_addr, cw20_contract_addr) = init_contracts(app);
-
-    // TODO check query config
-}

--- a/contracts/test01/src/tests/utils.rs
+++ b/contracts/test01/src/tests/utils.rs
@@ -1,30 +1,60 @@
-use classic_bindings::TerraQuery;
-use cosmwasm_std::testing::{mock_env, MockApi, MockStorage};
-use cosmwasm_std::{attr, Addr, Empty, Uint128};
-use cw_multi_test::{App, AppBuilder, BankKeeper, Contract, ContractWrapper, Executor};
-
 use crate::contract::{execute, instantiate, query};
 use crate::msg::InstantiateMsg;
+use classic_bindings::TerraQuery;
+use cosmwasm_std::{attr, Addr, Empty, Uint128};
+use cw_multi_test::{custom_app, BasicApp, Contract, ContractWrapper, Executor};
 
-pub fn mock_app() -> App {
-    let api = MockApi::default();
-    let env = mock_env();
-    let bank = BankKeeper::new();
-    let storage = MockStorage::new();
+const GOVERNANCE: &str = "governance";
+const TERRA: &str = "TERRA";
 
-    let app = AppBuilder::new()
-        .with_api(api)
-        .with_block(env.block)
-        .with_bank(bank)
-        .with_storage(storage)
-        .build(|_, _, _| {});
-    app
+pub type MyApp = BasicApp<Empty, TerraQuery>;
+
+pub fn my_app() -> MyApp {
+    custom_app::<Empty, TerraQuery, _>(|_, _, _| {})
 }
 
-pub fn init_contracts(app: &mut App) -> (Addr, Addr) {
-    let governance = Addr::unchecked("governance");
+/// Convenient utility function for creating addresses in tests.
+pub fn addr(input: &str) -> Addr {
+    Addr::unchecked(input)
+}
 
-    let contract = Box::new(ContractWrapper::new(
+/// Convenient utility function for creating governance address in tests.
+pub fn governance_addr() -> Addr {
+    addr(GOVERNANCE)
+}
+
+pub fn init_contracts(app: &mut MyApp) -> (Addr, Addr) {
+    let token_contract_addr = init_token_contract(app);
+    let test01_contract_addr = init_test01_contract(app, &token_contract_addr);
+    (test01_contract_addr, token_contract_addr)
+}
+
+pub fn init_test01_contract(app: &mut MyApp, token_contract_addr: &Addr) -> Addr {
+    let governance_addr = addr(GOVERNANCE);
+
+    let contract = ContractWrapper::new(execute, instantiate, query);
+    let contract: Box<(dyn Contract<Empty, TerraQuery> + 'static)> = Box::new(contract);
+
+    let code_id = app.store_code(contract);
+
+    app.instantiate_contract(
+        code_id,
+        governance_addr.clone(),
+        &InstantiateMsg {
+            owner: governance_addr.to_string(),
+            cw20_token: token_contract_addr.to_string(),
+        },
+        &[],
+        "staking",
+        None,
+    )
+    .unwrap()
+}
+
+pub fn init_token_contract(app: &mut MyApp) -> Addr {
+    let governance_addr = addr(GOVERNANCE);
+
+    let contract = Box::new(ContractWrapper::new_with_empty(
         cw20_base::contract::execute,
         cw20_base::contract::instantiate,
         cw20_base::contract::query,
@@ -33,66 +63,48 @@ pub fn init_contracts(app: &mut App) -> (Addr, Addr) {
     let code_id = app.store_code(contract);
 
     let instantiate_msg = cw20_base::msg::InstantiateMsg {
-        name: String::from("cw20 token"),
-        symbol: String::from("TERRA"),
+        name: "cw20 token".to_string(),
+        symbol: TERRA.to_string(),
         decimals: 6,
         initial_balances: vec![],
         mint: Some(cw20::MinterResponse {
-            minter: governance.to_string(),
+            minter: governance_addr.to_string(),
             cap: None,
         }),
         marketing: None,
     };
 
-    let cw20_token_contract_addr = app
-        .instantiate_contract(
-            code_id,
-            governance.clone(),
-            &instantiate_msg,
-            &[],
-            String::from("TERRA"),
-            None,
-        )
-        .unwrap();
-
-    let contract = ContractWrapper::new(execute, instantiate, query);
-    let contract: Box<(dyn Contract<Empty, TerraQuery> + 'static)> = Box::new(contract);
-
-    //// OMG HOW TO DO IT?????????????
-    let code_id = app.store_code(contract);
-
-    let test01_contract_addr = app
-        .instantiate_contract(
-            code_id,
-            governance,
-            &InstantiateMsg {
-                owner: governance.clone().to_string(),
-                cw20_token: cw20_token_contract_addr.to_string(),
-            },
-            &[],
-            "staking",
-            None,
-        )
-        .unwrap();
-
-    (test01_contract_addr, cw20_token_contract_addr)
+    app.instantiate_contract(
+        code_id,
+        governance_addr.clone(),
+        &instantiate_msg,
+        &[],
+        TERRA.to_string(),
+        None,
+    )
+    .unwrap()
 }
 
-pub fn mint_some_token(
-    app: &mut App,
-    owner: Addr,
-    token_contract_addr: Addr,
-    amount: Uint128,
-    to: String,
+pub fn mint_some_tokens(
+    app: &mut MyApp,
+    owner: &Addr,
+    token_contract_addr: &Addr,
+    amount: u128,
+    recipient: &Addr,
 ) {
+    let amount = Uint128::new(amount);
     let msg = cw20::Cw20ExecuteMsg::Mint {
-        recipient: to.clone(),
-        amount: amount,
+        recipient: recipient.to_string(),
+        amount,
     };
     let res = app
         .execute_contract(owner.clone(), token_contract_addr.clone(), &msg, &[])
         .unwrap();
+
     assert_eq!(res.events[1].attributes[1], attr("action", "mint"));
-    assert_eq!(res.events[1].attributes[2], attr("to", to));
+    assert_eq!(
+        res.events[1].attributes[2],
+        attr("to", recipient.to_string())
+    );
     assert_eq!(res.events[1].attributes[3], attr("amount", amount));
 }

--- a/contracts/test01/src/tests/utils.rs
+++ b/contracts/test01/src/tests/utils.rs
@@ -2,7 +2,7 @@ use crate::contract::{execute, instantiate, query};
 use crate::msg::InstantiateMsg;
 use classic_bindings::TerraQuery;
 use cosmwasm_std::{Addr, Empty, Uint128};
-use cw_multi_test::{custom_app, BasicApp, Contract, ContractWrapper, Executor};
+use cw_multi_test::{AppBuilder, BasicApp, Contract, ContractWrapper, Executor};
 
 const GOVERNANCE: &str = "governance";
 const TERRA: &str = "TERRA";
@@ -10,7 +10,7 @@ const TERRA: &str = "TERRA";
 pub type MyApp = BasicApp<Empty, TerraQuery>;
 
 pub fn my_app() -> MyApp {
-    custom_app::<Empty, TerraQuery, _>(|_, _, _| {})
+    AppBuilder::new_custom().build(|_, _, _| {})
 }
 
 /// Convenient utility function for creating addresses in tests.


### PR DESCRIPTION
Refactored and fixed the example.

---

# List of changes to make the code work

## Application must be created with custom query type
`src/tests/utils.rs`
```Rust
pub type MyApp = BasicApp<Empty, TerraQuery>;

pub fn my_app() -> MyApp {
    custom_app::<Empty, TerraQuery, _>(|_, _, _| {})
}
```

## CW20 contract must be created using `new_with_empty` constructor
`src/tests/utils.rs`
```Rust
let contract = Box::new(ContractWrapper::new_with_empty(
    cw20_base::contract::execute,
    cw20_base::contract::instantiate,
    cw20_base::contract::query,
));
```

---

The rest is just refactoring, fixing clippy warnings or adding some tests.